### PR TITLE
Add IP-wide maximums to the quantity of answers and questions you can have

### DIFF
--- a/node_modules/escape-html/LICENSE
+++ b/node_modules/escape-html/LICENSE
@@ -1,0 +1,24 @@
+(The MIT License)
+
+Copyright (c) 2012-2013 TJ Holowaychuk
+Copyright (c) 2015 Andreas Lubbe
+Copyright (c) 2015 Tiancheng "Timothy" Gu
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/node_modules/escape-html/Readme.md
+++ b/node_modules/escape-html/Readme.md
@@ -1,0 +1,43 @@
+
+# escape-html
+
+  Escape string for use in HTML
+
+## Example
+
+```js
+var escape = require('escape-html');
+var html = escape('foo & bar');
+// -> foo &amp; bar
+```
+
+## Benchmark
+
+```
+$ npm run-script bench
+
+> escape-html@1.0.3 bench nodejs-escape-html
+> node benchmark/index.js
+
+
+  http_parser@1.0
+  node@0.10.33
+  v8@3.14.5.9
+  ares@1.9.0-DEV
+  uv@0.10.29
+  zlib@1.2.3
+  modules@11
+  openssl@1.0.1j
+
+  1 test completed.
+  2 tests completed.
+  3 tests completed.
+
+  no special characters    x 19,435,271 ops/sec ±0.85% (187 runs sampled)
+  single special character x  6,132,421 ops/sec ±0.67% (194 runs sampled)
+  many special characters  x  3,175,826 ops/sec ±0.65% (193 runs sampled)
+```
+
+## License
+
+  MIT

--- a/node_modules/escape-html/index.js
+++ b/node_modules/escape-html/index.js
@@ -1,0 +1,78 @@
+/*!
+ * escape-html
+ * Copyright(c) 2012-2013 TJ Holowaychuk
+ * Copyright(c) 2015 Andreas Lubbe
+ * Copyright(c) 2015 Tiancheng "Timothy" Gu
+ * MIT Licensed
+ */
+
+'use strict';
+
+/**
+ * Module variables.
+ * @private
+ */
+
+var matchHtmlRegExp = /["'&<>]/;
+
+/**
+ * Module exports.
+ * @public
+ */
+
+module.exports = escapeHtml;
+
+/**
+ * Escape special characters in the given string of html.
+ *
+ * @param  {string} string The string to escape for inserting into HTML
+ * @return {string}
+ * @public
+ */
+
+function escapeHtml(string) {
+  var str = '' + string;
+  var match = matchHtmlRegExp.exec(str);
+
+  if (!match) {
+    return str;
+  }
+
+  var escape;
+  var html = '';
+  var index = 0;
+  var lastIndex = 0;
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escape = '&quot;';
+        break;
+      case 38: // &
+        escape = '&amp;';
+        break;
+      case 39: // '
+        escape = '&#39;';
+        break;
+      case 60: // <
+        escape = '&lt;';
+        break;
+      case 62: // >
+        escape = '&gt;';
+        break;
+      default:
+        continue;
+    }
+
+    if (lastIndex !== index) {
+      html += str.substring(lastIndex, index);
+    }
+
+    lastIndex = index + 1;
+    html += escape;
+  }
+
+  return lastIndex !== index
+    ? html + str.substring(lastIndex, index)
+    : html;
+}

--- a/node_modules/escape-html/package.json
+++ b/node_modules/escape-html/package.json
@@ -1,0 +1,83 @@
+{
+  "_args": [
+    [
+      "escape-html",
+      "C:\\Users\\Jason\\Documents\\GitHub\\rapidpoll"
+    ]
+  ],
+  "_from": "escape-html@latest",
+  "_id": "escape-html@1.0.3",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/escape-html",
+  "_npmUser": {
+    "email": "doug@somethingdoug.com",
+    "name": "dougwilson"
+  },
+  "_npmVersion": "1.4.28",
+  "_phantomChildren": {},
+  "_requested": {
+    "name": "escape-html",
+    "raw": "escape-html",
+    "rawSpec": "",
+    "scope": null,
+    "spec": "latest",
+    "type": "tag"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+  "_shasum": "0258eae4d3d0c0974de1c169188ef0051d1d1988",
+  "_shrinkwrap": null,
+  "_spec": "escape-html",
+  "_where": "C:\\Users\\Jason\\Documents\\GitHub\\rapidpoll",
+  "bugs": {
+    "url": "https://github.com/component/escape-html/issues"
+  },
+  "dependencies": {},
+  "description": "Escape string for use in HTML",
+  "devDependencies": {
+    "beautify-benchmark": "0.2.4",
+    "benchmark": "1.0.0"
+  },
+  "directories": {},
+  "dist": {
+    "shasum": "0258eae4d3d0c0974de1c169188ef0051d1d1988",
+    "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+  },
+  "files": [
+    "LICENSE",
+    "Readme.md",
+    "index.js"
+  ],
+  "gitHead": "7ac2ea3977fcac3d4c5be8d2a037812820c65f28",
+  "homepage": "https://github.com/component/escape-html",
+  "keywords": [
+    "escape",
+    "html",
+    "utility"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "email": "tj@vision-media.ca",
+      "name": "tjholowaychuk"
+    },
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    }
+  ],
+  "name": "escape-html",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/component/escape-html.git"
+  },
+  "scripts": {
+    "bench": "node benchmark/index.js"
+  },
+  "version": "1.0.3"
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "William Ye",
   "license": "ISC",
   "dependencies": {
+    "escape-html": "^1.0.3",
     "express": "^4.13.4",
     "jade": "^1.11.0",
     "serve-favicon": "^2.3.0",

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,35 +1,34 @@
 var socket = io();
 $(document).ready(function() {
-  
+
   var id = "";
-  socket.emit('join');
   var mSecondsLeft = 0;
-  
+
+  socket.emit('join');
+
   socket.on('join', function(data) {
     id = data.id;
-    for (key in data.answers) {
-      for (key2 in data.answers[key]) {
+    for (var key in data.answers) {
+      for (var key2 in data.answers[key]) {
         $('#answer-list ul').append(getAnswerSec(data.answers[key][key2]));
       }
     }
-    
+
     $('#question').html(data.question.question);
     socket.emit('get queue');
   });
-  
   function getAnswerSec(data) {
     if (data.answer.length > 300) {
       data.answer = data.answer.substring(0, 300);
     }
-    return "<li score='" + data.score + "'><div class='answer-sec'><div class='vote-div'><a onclick='upvote(\"" + data.id + "\", \"" + data.number + "\")' number='" + data.number + "' class='upvote' answer-id='" + data.id + "'><i class='material-icons'>arrow_upward</i></a><p class='score' answer-id='" + data.id + "' number='" + data.number + "'>" + data.score + "</p></div><div class='answer-div'><p>" + data.answer + "</p></div></div></li>";
     console.log(data.answer);
+    return "<li score='" + data.score + "'><div class='answer-sec'><div class='vote-div'><a onclick='upvote(\"" + data.id + "\", \"" + data.number + "\")' number='" + data.number + "' class='upvote' answer-id='" + data.id + "'><i class='material-icons'>arrow_upward</i></a><p class='score' answer-id='" + data.id + "' number='" + data.number + "'>" + data.score + "</p></div><div class='answer-div'><p>" + data.answer + "</p></div></div></li>";
   }
-      
+
   socket.on('new question sent', function(data) {
     if (data.question.length > 300) {
       data.question = data.question.substring(0, 300);
     }
-    document.title
     $('#question').html(data.question);
     document.title = 'rapidpoll: ' + data.question;
     socket.emit('get queue');
@@ -43,65 +42,63 @@ $(document).ready(function() {
     }
     $("#answer-input").prop('disabled', false);
     $('#answer-input').attr('placeholder', 'post an answer');
-    
+
   });
-  
+
   socket.on('new question entered', function(data) {
     socket.emit('get queue');
     console.log('total questions: ' + data);
   });
-  
+
   socket.on('get queue', function(data) {
     if (data.place != 'n/a') {
       $('#question-input').attr('placeholder', 'your question\'s position in queue: ' + data.place + '/' + data.total);
     }
     $('#queue').html('questions in queue: ' + data.total);
   });
-  
+
   socket.on('new answer', function(data) {
-    
     $('#answer-list ul').append(getAnswerSec(data));
   });
-  
+
   socket.on('upvote', function(data) {
     console.log('upvote gotten: ' + data.id);
     $('.score[answer-id="' + data.id + '"][number = "' + data.number + '"]').html(data.score);
     $('.score[answer-id="' + data.id + '"][number = "' + data.number + '"]').parent().parent().parent().attr('score', data.score);
     //sortAnswers();
-    
   });
-  
+
   socket.on('timer', function(data) {
-    if (data.secondsLeft == 0) {
+    if (data.secondsLeft === 0) {
       $('#timer').css('width', $('#question-div').width() + 30);
     } else {
       $('#timer').css('width', ($('#question-div').width() + 20) - ((data.secondsLeft - 1) / data.questionDuration * $('#question-div').width() + 20));
     }
   });
-  
+
   socket.on('clients online', function(data) {
     console.log(data);
     $('#online').html('clients online: ' + data);
   });
-  
+
   socket.on('max answers', function() {
     $("#answer-input").prop('disabled', true);
     $('#answer-input').val('');
     $('#answer-input').attr('placeholder', 'max number of answers reached');
   });
-  
+
   $("#question-input").keyup(function(event){
     if(event.keyCode == 13){
       $("#question-submit").click();
     }
   });
-  
+
   $("#answer-input").keyup(function(event){
     if(event.keyCode == 13){
       $("#answer-submit").click();
     }
   });
-  
+
   $('#question-submit').click(function() {
     if ($('#question-submit i').html() == 'send') {
       if (/\S/.test($('#question-input').val())) {
@@ -126,13 +123,11 @@ $(document).ready(function() {
     }
     $('#answer-input').val('');
   });
-  
+
   socket.on('remove answers', function(data) {
     $('p[answer-id="' + data + '"]').parent().parent().parent().remove();
   });
 
-
-  
 });
 function upvote(id, number) {
   console.log('upvote clicked');
@@ -141,7 +136,6 @@ function upvote(id, number) {
 }
 
 function sortAnswers() { //http://jsfiddle.net/MikeGrace/Vgavb/
-  
   // get array of elements
   var myArray = $("#answer-list li");
   var count = 0;

--- a/server.js
+++ b/server.js
@@ -18,31 +18,30 @@ var secondsLeft = 0;
 var currentQuestion = {question: '', id: ''};
 var maxAnswers = 3;
 
-
 app.get('/', function(req, res){
   res.render('index');
 });
 
 socket.on('connection', function(client) {
-  
+
   client.on('join', function() {
-    console.log('User with id ' + client.id + " connected")
+    console.log('User with id ' + client.id + " connected");
     clients[client.id] = {upvoted: []};
     client.emit('join', {id: client.id, answers: answers, question: currentQuestion});
     console.log(clients);
     socket.emit('clients online', Object.keys(clients).length);
   });
-  
+
   client.on('disconnect', function() {
-    console.log('User ' + client.id + " disconnected")
+    console.log('User ' + client.id + " disconnected");
     delete questions[client.id];
     var upvotedId;
     var upvotedNumber;
     if (typeof clients[client.id] != 'undefined') {
-      for (i in clients[client.id].upvoted) {
+      for (var i in clients[client.id].upvoted) {
         upvotedId = clients[client.id].upvoted[i].id;
         upvotedNumber = clients[client.id].upvoted[i].number;
-        
+
         answers[upvotedId][upvotedNumber].score--;
         socket.emit('upvote', answers[upvotedId][upvotedNumber]);
       }
@@ -52,7 +51,7 @@ socket.on('connection', function(client) {
     delete clients[client.id];
     socket.emit('clients online', Object.keys(clients).length);
   });
-  
+
   client.on('submit question', function(data) {
     data = data.replace(/</g, "&lt;").replace(/>/g, "&gt;");
     console.log('question received: ' + data);
@@ -66,19 +65,18 @@ socket.on('connection', function(client) {
       console.log('blank question');
     }
   });
-  
+
   client.on('clear question', function() {
     delete questions[client.id];
     console.log('cleared question, ' + questions);
   });
-  
+
   client.on('submit answer', function(data) {
     data = data.replace(/</g, "&lt;").replace(/>/g, "&gt;");
     if (typeof answers[client.id] == "undefined") {
       answers[client.id] = [];
-    } 
+    }
     if (answers[client.id].length < maxAnswers && /\S/.test(data)) {
-      
       answers[client.id].push({answer: data, id: client.id, score: 0, number:answers[client.id].length});
       socket.emit('new answer', answers[client.id][answers[client.id].length - 1]);
       if (answers[client.id].length == maxAnswers) {
@@ -87,9 +85,9 @@ socket.on('connection', function(client) {
     } else {
       console.log('too many answers');
     }
-    
+
   });
-  
+
   client.on('get queue', function() {
     var place = 0;
     for(var key in questions) {
@@ -101,49 +99,51 @@ socket.on('connection', function(client) {
     }
     client.emit('get queue', {place: 'n/a', total: Object.keys(questions).length});
   });
-  
+
   client.on('upvote', function(data) {
-    for (i in clients[client.id].upvoted) {
-      if (clients[client.id].upvoted[i].id == data.id && clients[client.id].upvoted[i].number == data.number) {
-        console.log('downvote inc');
+    for (var i in clients[client.id].upvoted) {
+      var hasAlreadyVoted = clients[client.id].upvoted[i].id == data.id && clients[client.id].upvoted[i].number == data.Number;
+      if (hasAlreadyVoted) {
+        console.log('removing their vote, downvote inc');
         clients[client.id].upvoted.splice(i, 1);
         answers[data.id][data.number].score--;
         console.log(answers[data.id].score);
-        for (i in answers[data.id]) {
-          if (answers[data.id][i].number == data.number) {
-            socket.emit('upvote', answers[data.id][i]);
+        for (var i2 in answers[data.id]) {
+          if (answers[data.id][i2].number == data.number) {
+            socket.emit('upvote', answers[data.id][i2]);
             break;
           }
         }
-        
+
         return;
       }
     }
-    
+
     answers[data.id][data.number].score++;
     console.log('we upvoting this shit: ' + answers[data.id][data.number].score);
-    for (i in answers[data.id]) {
-      if (answers[data.id][i].number == data.number) {
-        socket.emit('upvote', answers[data.id][i]);
+    for (var i3 in answers[data.id]) {
+      if (answers[data.id][i3].number == data.number) {
+        socket.emit('upvote', answers[data.id][i3]);
         break;
       }
     }
     clients[client.id].upvoted.push({id:data.id, number:data.number});
-  })
+  });
 });
 
-http.listen(process.env.PORT || 3000, function(){
-  console.log('listening on *:3000');
+var port = process.env.PORT || 3000;
+http.listen(port, function(){
+  console.log('listening on *:', port);
 });
 
 newQuestion();
 
 function newQuestion() {
   answers = {};
-  for (key in clients) {
+  for (var key in clients) {
     clients[key].upvoted = [];
   }
-  if (Object.keys(questions).length != 0) {
+  if (Object.keys(questions).length !== 0) {
     socket.emit('new question sent', questions[Object.keys(questions)[0]]);
     currentQuestion = questions[Object.keys(questions)[0]];
     console.log('id of question to be deleted: ' + Object.keys(questions)[0]);
@@ -151,13 +151,14 @@ function newQuestion() {
 //    console.log('deleted ' + questions);
     secondsLeft = questionDuration;
     socket.emit('timer', {secondsLeft: secondsLeft, questionDuration: questionDuration});
+
     timer();
   } else {
     console.log('No questions in queue...');
     currentQuestion = {question: '', id: ''};
-    socket.emit('new question sent', {question: 'no questions, why don\'t you start us off and create a new one?', id:'n/a'})
+    socket.emit('new question sent', {question: 'no questions, why don\'t you start us off and create a new one?', id:'n/a'});
+
     setTimeout(function(){
-      
       newQuestion();
     }, 2000);
   }
@@ -172,5 +173,5 @@ function timer() {
     } else {
       newQuestion();
     }
-  }, 1000)
+  }, 1000);
 }

--- a/server.js
+++ b/server.js
@@ -22,8 +22,7 @@ app.get('/', function(req, res){
   res.render('index');
 });
 
-socket.on('connection', function(client) {
-
+function runClient(client) {
   client.on('join', function() {
     console.log('User with id ' + client.id + " connected");
     clients[client.id] = {upvoted: []};
@@ -129,6 +128,14 @@ socket.on('connection', function(client) {
     }
     clients[client.id].upvoted.push({id:data.id, number:data.number});
   });
+}
+
+socket.on('connection', function(client) {
+  try {
+    runClient(client);
+  } catch (e) {
+    console.error('Client crashed with error: ', e);
+  }
 });
 
 var port = process.env.PORT || 3000;

--- a/views/index.jade
+++ b/views/index.jade
@@ -14,12 +14,12 @@ html
       
       #question-div
         
-        h2#question
+        h2#question Loading...
         #timer
         
       #input-container
         .input-div
-          input#answer-input(type='text', placeholder='post an answer')
+          input#answer-input(type='text', disabled, placeholder='no question to answer')
           .submit-div
             a#answer-submit
               i.material-icons send


### PR DESCRIPTION
This isn't quite IP banning, though you can leverage the code here to implement that if you'd like. This code will maintain the current question and answer limitations while also adding in configurable limitations that are IP-wide. I have set this to 3 questions and 6 answers max per IP address. If they try to add more, the server will reject it and send an event that lets them know they've hit the maximum answer/questions. This is IP-wide, so it'll work cross-browser.

Now, if your app becomes more popular to the point where IP-wide limitations are too restricting, you may want to look into "user fingerprinting" to uniquely identify users without having to limit as much on an IP-wide spectrum.

This PR also:
- Polishes JS to improve readability and fix JSHint warnings.
- Prevents potential server-wide crashes potentially caused by single sockets blowing up. We wrap the entirety of the client socket setup in a try/catch to do this.
- Improves the HTML escaping by using a more all-encompassing method via the escape-html NPM module. (Escapes slightly more than just `>` and `<`.)
- Load the current question faster on initial load.
- Disable the answer field if there is no question.

Please don't hesitate to leave questions or comments of any kind. Of course, feel free to either merge this PR or just use some of the code here to give you ideas, if you'd prefer to code everything yourself. Whatever you  do, if you're considering using the code here, I'd recommend testing it yourself locally - I did the same, but having a second set of hands is a great idea.

There are a decent amount of structural changes to the code, so I'd recommend you go through this PR by clicking on each individual commit, to see only the changes I made in those specific commits. Will make it easier to comb through the code. I'll also be commenting throughout the code to try to explain myself better.

@williamyeny

P.S. Awesome project, really cool idea.
